### PR TITLE
Fix orphaned glances process leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,90 @@
+# Changelog
+
+All notable changes to this project will be documented here.
+
+## v1.1 — Fix orphaned `glances` process leak
+
+### Background
+
+The previous sampling line used a shell pipeline:
+
+```bash
+RAW_OUTPUT=$(timeout "$CPU_MEASURE_SECONDS" glances --stdout cpu.total,mem,fs --time 1 2>/dev/null | tail -n 3)
+```
+
+Under cron, this had a race:
+
+1. `tail -n 3` closes its stdin once it has received 3 lines.
+2. `timeout`'s SIGPIPE/SIGTERM to the child `glances` process was not
+   always propagated quickly enough.
+3. The command-substitution subshell exited while the `glances` python
+   process (and sometimes `timeout` itself) remained running.
+4. Each cron tick could therefore leak a full process chain:
+   `sh → bash → bash → timeout → python`.
+
+One production deployment accumulated roughly 45 orphaned `glances`
+processes over 127 days, consuming about 1.5 CPU cores and 7.9 GB of RAM
+continuously. Load average on the host sat near 4.0 until the orphans
+were killed manually.
+
+A secondary config-layout bug had also surfaced in at least one deployed
+copy: `CHECK_CPU=1CHECK_MEM=1` ended up collapsed onto a single line,
+silently disabling the memory check.
+
+### Fix
+
+- **No more `glances | tail` pipeline.** Glances output is written to a
+  tempfile (`mktemp`) and read back with `tail -n 20`. This removes the
+  SIGPIPE race entirely.
+- **`timeout --kill-after`** is now used on every `glances` invocation
+  so SIGKILL is guaranteed if SIGTERM is ignored.
+- **EXIT/INT/TERM trap** reaps any leftover children of the current
+  script using `pgrep -P $$`. The `-P $$` filter is intentional: it
+  never touches unrelated `glances` processes on the host (for example,
+  a `glances -s -B 127.0.0.1` server).
+- **`flock`** on `/tmp/glances-alert.lock` prevents overlapping runs if
+  one tick runs longer than the cron interval.
+- **`curl --max-time 10`** stops a slow Slack webhook from hanging the
+  script.
+- **`set -u`** is now enabled to catch undefined-variable bugs.
+- Each `CHECK_*` config flag is explicitly kept on its own line.
+
+### Upgrade steps for existing deployments
+
+Before deploying the new script, clean up any orphans left by the old
+version. The `pkill` patterns below are deliberately specific — they
+match the invocation pattern used by this script and will not touch a
+separately-running `glances -s -B …` server on the same host.
+
+1. Disable the cron entry:
+   ```bash
+   crontab -e          # prefix the glances-alert line with #
+   ```
+
+2. Count existing orphans:
+   ```bash
+   ps -eo pid,cmd | grep "glances --stdout" | grep -v grep | wc -l
+   ```
+
+3. Kill orphans:
+   ```bash
+   pkill -9 -f "python3 /usr/bin/glances --stdout"
+   pkill -9 -f "timeout .* glances --stdout"
+   ```
+
+4. Deploy the new `glances-alert.sh`.
+
+5. Re-enable the cron entry.
+
+6. After ~10 minutes, verify no new leaks have appeared:
+   ```bash
+   ps -eo pid,etime,cmd | grep "glances --stdout" | grep -v grep
+   ```
+   Any matching process should show an `ELAPSED` value smaller than the
+   cron interval.
+
+### New dependencies
+
+- `flock` (`util-linux`)
+- `timeout` with `--kill-after` support (`coreutils` ≥ 8.5 — satisfied
+  by all currently-supported Ubuntu releases)

--- a/README.md
+++ b/README.md
@@ -4,12 +4,29 @@ This project provides a lightweight Bash script that monitors **CPU**, **memory*
 
 ## 🔧 Features
 
-* ✅ Uses `glances` with `--stdout-json` mode
-* ✅ Parses CPU, memory, and disk usage via `jq`
+* ✅ Uses `glances` with `--stdout` mode
+* ✅ Parses CPU, memory, and disk usage from the text output
 * ✅ Sends alerts to a Slack channel using Incoming Webhooks
 * ✅ Throttles alerts to avoid spam (default: 10-minute interval)
 * ✅ Includes a detailed debug log (`/tmp/glances-alert.log`)
 * ✅ Adds hostname to the Slack alert for easy server identification
+
+---
+
+## ⚠️ Known issue fixed in v1.1
+
+Versions prior to v1.1 used a `timeout … glances … | tail -n 3` pipeline
+to sample Glances. A race between `tail` closing its input and `timeout`
+signalling its child could leave orphaned `glances` python processes
+behind on every cron tick. One production host accumulated ~45 leaked
+processes over 127 days (~1.5 cores and ~7.9 GB RAM, load average ~4.0).
+
+**If you are running an older copy of this script, please upgrade and
+follow the steps in [`CHANGELOG.md`](./CHANGELOG.md) to clean up any
+orphans before the new version starts running.** The new version
+captures Glances output to a tempfile, uses `timeout --kill-after` to
+guarantee a SIGKILL fallback, reaps its own children on exit, and uses
+`flock` to prevent overlapping runs.
 
 ---
 
@@ -19,8 +36,12 @@ Install dependencies:
 
 ```bash
 sudo apt update
-sudo apt install -y glances jq bc curl
+sudo apt install -y glances bc curl util-linux coreutils
 ```
+
+* `flock` ships with `util-linux`
+* `timeout` (with `--kill-after`) requires `coreutils` ≥ 8.5, which all
+  currently-supported Ubuntu releases provide
 
 ---
 

--- a/glances-alert.sh
+++ b/glances-alert.sh
@@ -1,53 +1,100 @@
 #!/bin/bash
+#
+# glances-alert.sh
+#
+# Lightweight system monitor that reads CPU / memory / disk usage from
+# `glances --stdout` and posts a Slack alert when thresholds are exceeded.
+#
 
-# CONFIGURATION
+set -u
+
+# ---------- CONFIGURATION ------------------------------------------------
+
 CHECK_CPU=1
 CHECK_MEM=1
 CHECK_DISK=1
+
 SLACK_WEBHOOK_URL="https://hooks.slack.com/services/XXX/YYY/ZZZ"
+
 CPU_THRESHOLD=90
 MEM_THRESHOLD=80
 DISK_THRESHOLD=80
+
 ALERT_COOLDOWN_MINUTES=10
+
 STATE_FILE="/tmp/glances-alert.last"
 LOG_FILE="/tmp/glances-alert.log"
+LOCK_FILE="/tmp/glances-alert.lock"
+
 HOSTNAME=$(hostname)
 
-# CPU measurement window in seconds (increase for more stable readings)
 CPU_MEASURE_SECONDS=5
+GLANCES_KILL_AFTER_SECONDS=2
+
+# ---------- HELPERS ------------------------------------------------------
 
 log() {
     echo "$(date '+%Y-%m-%d %H:%M:%S') | $1" >> "$LOG_FILE"
 }
 
+TMP_OUT="$(mktemp -t glances-alert.XXXXXX)"
+
+cleanup() {
+    local children
+    children=$(pgrep -P $$ 2>/dev/null || true)
+    if [ -n "$children" ]; then
+        # shellcheck disable=SC2086
+        kill $children 2>/dev/null || true
+        sleep 1
+        # shellcheck disable=SC2086
+        kill -9 $children 2>/dev/null || true
+    fi
+    rm -f "$TMP_OUT"
+}
+trap cleanup EXIT INT TERM
+
+# ---------- PREVENT OVERLAPPING RUNS ------------------------------------
+
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+    log "Another glances-alert run is already in progress. Skipping."
+    exit 0
+fi
+
 log "Starting glances-alert.sh script"
 
-# Run Glances for longer period to get averaged CPU usage
-# The last reading from glances will be the average over the time period
-RAW_OUTPUT=$(timeout $CPU_MEASURE_SECONDS glances --stdout cpu.total,mem,fs --time 1 2>/dev/null | tail -n 3)
+# ---------- SAMPLE GLANCES ----------------------------------------------
 
-# If timeout doesn't give us output, fall back to single reading
-if [ -z "$RAW_OUTPUT" ]; then
-    log "Falling back to single glances reading"
-    RAW_OUTPUT=$(timeout 2 glances --stdout cpu.total,mem,fs)
+timeout --kill-after="${GLANCES_KILL_AFTER_SECONDS}s" "${CPU_MEASURE_SECONDS}s" \
+    glances --stdout cpu.total,mem,fs --time 1 \
+    > "$TMP_OUT" 2>/dev/null
+GLANCES_RC=$?
+
+if [ ! -s "$TMP_OUT" ]; then
+    log "Primary glances reading produced no output (rc=$GLANCES_RC), trying fallback"
+    timeout --kill-after="${GLANCES_KILL_AFTER_SECONDS}s" 2s \
+        glances --stdout cpu.total,mem,fs \
+        > "$TMP_OUT" 2>/dev/null
 fi
+
+if [ ! -s "$TMP_OUT" ]; then
+    log "ERROR: glances produced no output in either attempt. Aborting."
+    exit 1
+fi
+
+RAW_OUTPUT=$(tail -n 20 "$TMP_OUT")
 
 log "Raw glances output:"
 log "$RAW_OUTPUT"
 
-# Extract CPU usage - looking specifically for the cpu.total line
-CPU_USAGE=$(echo "$RAW_OUTPUT" | grep "cpu.total:" | tail -1 | awk '{print $2}')
+# ---------- PARSE --------------------------------------------------------
 
-# If that doesn't work, try alternative parsing
+CPU_USAGE=$(echo "$RAW_OUTPUT" | grep "cpu.total:" | tail -1 | awk '{print $2}')
 if [ -z "$CPU_USAGE" ] || ! [[ "$CPU_USAGE" =~ ^[0-9.]+$ ]]; then
-    # Look for the pattern "cpu.total: <number>"
     CPU_USAGE=$(echo "$RAW_OUTPUT" | sed -n 's/^cpu\.total: \([0-9.]*\)/\1/p' | tail -1)
 fi
 
-# Extract memory usage - look for percent within mem section
 MEM_USAGE=$(echo "$RAW_OUTPUT" | sed -n "/^mem:/,/^[a-z]/s/.*'percent': \([0-9.]*\).*/\1/p" | head -n1)
-
-# Extract disk usage - look for percent within fs section
 DISK_USAGE=$(echo "$RAW_OUTPUT" | sed -n "/^fs:/,/^[a-z]/s/.*'percent': \([0-9.]*\).*/\1/p" | head -n1)
 
 log "Parsed values:"
@@ -55,7 +102,6 @@ log "CPU_USAGE=$CPU_USAGE% (${CPU_MEASURE_SECONDS}-second measurement)"
 log "MEM_USAGE=$MEM_USAGE%"
 log "DISK_USAGE=$DISK_USAGE%"
 
-# Check values are numeric
 if ! [[ "$CPU_USAGE" =~ ^[0-9.]+$ && "$MEM_USAGE" =~ ^[0-9.]+$ && "$DISK_USAGE" =~ ^[0-9.]+$ ]]; then
     log "ERROR: One of the values is not numeric"
     log "DEBUG: CPU_USAGE=$CPU_USAGE"
@@ -64,7 +110,8 @@ if ! [[ "$CPU_USAGE" =~ ^[0-9.]+$ && "$MEM_USAGE" =~ ^[0-9.]+$ && "$DISK_USAGE" 
     exit 1
 fi
 
-# Build alert message
+# ---------- BUILD ALERT --------------------------------------------------
+
 ALERT_MSG=""
 if [ "$CHECK_CPU" -eq 1 ] && (( $(echo "$CPU_USAGE > $CPU_THRESHOLD" | bc -l) )); then
     ALERT_MSG+="⚠️ *High CPU usage*: ${CPU_USAGE}%\n"
@@ -79,7 +126,8 @@ if [ "$CHECK_DISK" -eq 1 ] && (( $(echo "$DISK_USAGE > $DISK_THRESHOLD" | bc -l)
     log "Disk usage exceeded threshold"
 fi
 
-# Handle Slack alert with throttling
+# ---------- SEND SLACK (with cooldown) ----------------------------------
+
 if [ -n "$ALERT_MSG" ]; then
     CURRENT_TIME=$(date +%s)
     LAST_ALERT_TIME=0
@@ -92,11 +140,13 @@ if [ -n "$ALERT_MSG" ]; then
     log "Time since last alert: $TIME_DIFF minutes"
 
     if [ "$TIME_DIFF" -ge "$ALERT_COOLDOWN_MINUTES" ]; then
-        curl -s -X POST -H 'Content-type: application/json' \
+        if curl -s --max-time 10 -X POST -H 'Content-type: application/json' \
             --data "{\"text\":\"*🚨 Alert from $HOSTNAME:*\n$ALERT_MSG\"}" \
-            "$SLACK_WEBHOOK_URL" \
-            && log "Slack alert sent." \
-            || log "ERROR: Failed to send Slack alert."
+            "$SLACK_WEBHOOK_URL"; then
+            log "Slack alert sent."
+        else
+            log "ERROR: Failed to send Slack alert."
+        fi
 
         echo "$CURRENT_TIME" > "$STATE_FILE"
     else
@@ -106,5 +156,4 @@ else
     log "No thresholds exceeded. No alert sent."
 fi
 
-# Optional: Add a status line to the log showing current metrics
 log "STATUS: CPU=${CPU_USAGE}%, MEM=${MEM_USAGE}%, DISK=${DISK_USAGE}%"


### PR DESCRIPTION
## Summary

The sampling line in `glances-alert.sh` used a `timeout … glances … | tail -n 3` pipeline. Under cron, a race between `tail` closing its stdin and `timeout` signalling its child could leave an orphaned `glances` python process on every tick. One production host accumulated ~45 orphans over 127 days (~1.5 cores and ~7.9 GB RAM, load average ~4.0).

## Root cause

1. `tail -n 3` closes its input after 3 lines.
2. `timeout`'s SIGPIPE/SIGTERM to `glances` is not always propagated in time.
3. The `$(…)` subshell exits, but the `glances` python process (and occasionally `timeout` itself) keeps running.
4. Each cron tick can leak a full `sh → bash → bash → timeout → python` chain.

A secondary bug on the same line as `CHECK_CPU=1` had surfaced in at least one deployed copy: `CHECK_CPU=1CHECK_MEM=1` got collapsed onto a single line, silently disabling the memory check. Each `CHECK_*` flag is now explicitly on its own line.

## Changes

- Replace `glances | tail` pipe with a tempfile (`mktemp`) + `tail -n 20` read — removes the SIGPIPE race.
- `timeout --kill-after=2s 5s glances …` on every invocation, guaranteeing SIGKILL if SIGTERM is ignored.
- `trap cleanup EXIT INT TERM` reaps any remaining children using `pgrep -P $$`. The `-P $$` filter is deliberate: it only targets children of this script and will never touch unrelated `glances` processes on the host (e.g. a `glances -s -B 127.0.0.1` server).
- `flock -n` on `/tmp/glances-alert.lock` prevents overlapping runs when one tick takes longer than the cron interval.
- `curl --max-time 10` so a slow Slack webhook can't hang the script.
- `set -u` to catch undefined-variable bugs.
- README refreshed: added a "Known issue fixed in v1.1" section, updated requirements (`flock` from `util-linux`, `timeout` from `coreutils` ≥ 8.5, no more `jq`), and corrected the outdated `--stdout-json`/`jq` claims to match what the script actually does.
- New `CHANGELOG.md` with the full story and runbook.

## Verification

- `bash -n glances-alert.sh` → OK
- `shellcheck glances-alert.sh` → 0 warnings (SC2015 on the `curl && log || log` pattern addressed by converting to `if/else`)
- The Slack webhook placeholder (`XXX/YYY/ZZZ`) is preserved.

## Upgrade steps for existing deployments

1. Comment out the glances-alert.sh cron entry:
   ```
   crontab -e          # prefix the glances-alert line with #
   ```

2. Count existing orphans:
   ```
   ps -eo pid,cmd | grep "glances --stdout" | grep -v grep | wc -l
   ```

3. Kill orphans (safe: only matches the leaked invocation pattern, will NOT touch `glances -s -B 127.0.0.1` servers):
   ```
   pkill -9 -f "python3 /usr/bin/glances --stdout"
   pkill -9 -f "timeout .* glances --stdout"
   ```

4. Deploy the new glances-alert.sh.

5. Re-enable the cron entry.

6. After ~10 minutes, verify no new leaks:
   ```
   ps -eo pid,etime,cmd | grep "glances --stdout" | grep -v grep
   ```
   Any output should show `ELAPSED` < cron interval.

## Test plan

- [ ] Deploy to a staging host and confirm each cron tick leaves zero `glances --stdout` processes afterwards
- [ ] Force a threshold breach and confirm Slack alert + `STATE_FILE` update
- [ ] Start a long-running tick (e.g. block `glances` with a firewall rule) and confirm the next cron tick exits cleanly via `flock`
- [ ] Confirm an unrelated `glances -s -B 127.0.0.1` server on the same host is NOT affected by the cleanup trap

🤖 Generated with [Claude Code](https://claude.com/claude-code)